### PR TITLE
Hide org-mode properties drawer

### DIFF
--- a/src/orgile.php
+++ b/src/orgile.php
@@ -53,10 +53,11 @@ class orgile {
 
     $regex = array(
        // roam
-       '/^\#\+title:{1}\s+?(.+)/i',         # #+TITLE:
+       '/^\#\+title:{1}\s+?(.+)/im',         # #+TITLE:
        '/^\#\+roam_tags:{1}\s+?(.+)/im',     # #+ROAM_TAGS:
        '/^\#\+created:{1}\s+?(.+)/im',       # #+CREATED:
        '/^\#\+last_modified:{1}\s+?(.+)/im', # #+LAST_MODIFIED:
+       '/^:properties:[\s\S]*?:end:(.*)/im', # :PROPERTIES: id :END:
 
 		   // headings
 		   '/^\*{1}\s+?(.+)/m', // * example
@@ -125,7 +126,7 @@ class orgile {
          "<div class=roam_tags>$1</div>",
          "<div class=created>$1</div>",
          "<div class=last_modified>$1</div>",
-
+         "",
 
 		     // headings
 		     "<h2>$1</h2>\n", // * example


### PR DESCRIPTION
Soon-to-come [org-roam v2 ](https://github.com/org-roam/org-roam/releases/tag/2.0.0a1) will require IDs for all elements, including files. These go into a :PROPERTIES: ... :END: folder at the beginning of the page. For now the easiest way deal with this is probably just to hide all of it.